### PR TITLE
Fix: text should be aligned to the left side

### DIFF
--- a/src/main/java/pro/gravit/launcher/client/gui/scenes/options/OptionsScene.java
+++ b/src/main/java/pro/gravit/launcher/client/gui/scenes/options/OptionsScene.java
@@ -2,6 +2,7 @@ package pro.gravit.launcher.client.gui.scenes.options;
 
 import com.google.gson.reflect.TypeToken;
 import javafx.geometry.Insets;
+import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;

--- a/src/main/java/pro/gravit/launcher/client/gui/scenes/options/OptionsScene.java
+++ b/src/main/java/pro/gravit/launcher/client/gui/scenes/options/OptionsScene.java
@@ -117,6 +117,7 @@ public class OptionsScene extends AbstractScene {
         Label desc = new Label();
         desc.setWrapText(true);
         desc.setText(description);
+        StackPane.setAlignment(desc, Pos.BASELINE_LEFT);
         container.getChildren().add(checkBox);
         container.getChildren().add(new StackPane(desc));
         checkBox.setOnAction((e) -> onChanged.accept(checkBox.isSelected()));


### PR DESCRIPTION
By default StackPane tries to put everything to the middle of it ( when children.width < pane.width ). This causes some weird text positioning when you have a large description of a mod, and a small one.
![image](https://user-images.githubusercontent.com/9916915/132989530-db3664df-c654-49d6-94a9-013916edc73c.png)
