### PR TITLE
Fix: Some optional mods can have visual de-sync

### DIFF
--- a/src/main/java/pro/gravit/launcher/client/gui/scenes/options/OptionsScene.java
+++ b/src/main/java/pro/gravit/launcher/client/gui/scenes/options/OptionsScene.java
@@ -93,8 +93,8 @@ public class OptionsScene extends AbstractScene {
 
     public void addProfileOptionals(OptionalView view) {
         this.optionalView = new OptionalView(view);
+        watchers.clear();
         for (OptionalFile optionalFile : optionalView.all) {
-            watchers.clear();
             if (!optionalFile.visible)
                 continue;
 


### PR DESCRIPTION
Because map was cleared in every loop cycle it would mean that callWatcher wouldn't be able to find checkmark when user, for example, selected mod A that automatically disabled mod B due to them being in conflict.