### PR TITLE
fix: totalSize shouldn't reset just after it was calculated

### DIFF
--- a/src/main/java/pro/gravit/launcher/client/gui/scenes/update/VisualDownloader.java
+++ b/src/main/java/pro/gravit/launcher/client/gui/scenes/update/VisualDownloader.java
@@ -241,11 +241,12 @@ public class VisualDownloader {
         totalDownloaded.set(0);
         lastUpdateTime.set(System.currentTimeMillis());
         lastDownloaded.set(0);
-        totalSize = 0;
         progressBar.progressProperty().setValue(0);
     }
 
     private List<AsyncDownloader.SizedFile> getFilesList(Path dir, LinkedList<PathRemapperData> pathRemapper, HashedDir mismatch) throws IOException {
+        totalSize = 0;
+
         final List<AsyncDownloader.SizedFile> adds = new ArrayList<>();
         mismatch.walk(IOHelper.CROSS_SEPARATOR, (path, name, entry) -> {
             String urlPath = path;


### PR DESCRIPTION
resetProgress is called right after getFilesList.
Personally, I think this is better flow anyway because we calculate and reset totalSize in same place now.