### PR TITLE
Сброс состояния authFlow после выхода из аккаунта

### DIFF
--- a/src/main/java/pro/gravit/launcher/client/gui/scenes/login/LoginScene.java
+++ b/src/main/java/pro/gravit/launcher/client/gui/scenes/login/LoginScene.java
@@ -250,7 +250,8 @@ public class LoginScene extends AbstractScene {
 
     @Override
     public void reset() {
-
+        authFlow.authFlow.clear();
+        authFlow.authFlow.add(0);
     }
 
     @Override


### PR DESCRIPTION
До правки, при выходе, запрашивался сразу 2фа, и на сервер уходил пейлоад без логина и пароля, что не поддерживается сервером, приводит к ошибке авторизации.

После правки, при выходе, сбрасывается состояние authFlow и после выхода, при повторном входе флоу начинается сначала